### PR TITLE
Move from 'include' to 'include_tasks'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for ansible-openvswitch
 
-openvswitch_bridges_list: []
+openvswitch_bridges: []
 # - bridge: 'br-int'
 #   state: 'present'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for ansible-openvswitch
 
 openvswitch_bridges_list: []
-# - name: 'br-int'
+# - bridge: 'br-int'
 #   state: 'present'
 
 openvswitch_debian_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,22 +1,22 @@
 ---
 # defaults file for ansible-openvswitch
 
-openvswitch_bridges: []
-  # - bridge: 'br-int'
-  #   state: 'present'
+openvswitch_bridges_list: []
+# - name: 'br-int'
+#   state: 'present'
 
 openvswitch_debian_packages:
   - 'openvswitch-switch'
   - 'openvswitch-common'
 
 openvswitch_ports: []
-  # - bridge: 'br-int'
-  #   ports:
-  #     - port: 'enp0s9'
-  #       state: 'present'
-  #     - port: 'enp0s10'
-  #       state: 'present'
+# - bridge: 'br-int'
+#   ports:
+#     - port: 'enp0s9'
+#       state: 'present'
+#     - port: 'enp0s10'
+#       state: 'present'
 
 openvswitch_system_tuning: []
-  # - name: 'net.ipv4.ip_forward'
-  #   value: 1
+# - name: 'net.ipv4.ip_forward'
+#   value: 1

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,14 +4,17 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 2.3
+  min_ansible_version: 2.10
 
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
+        - focal
 
   galaxy_tags:
     - networking
 
 dependencies: []
+
+collections:
+  - openvswitch.openvswitch

--- a/tasks/bridges.yml
+++ b/tasks/bridges.yml
@@ -9,4 +9,4 @@
     vlan: "{{ item['vlan']|default(omit) }}"
   become: true
   with_items: '{{ openvswitch_bridges }}'
-  when: openvswitch_bridges is defined
+  when: openvswitch_bridges is defined and not ansible_check_mode

--- a/tasks/bridges.yml
+++ b/tasks/bridges.yml
@@ -1,12 +1,12 @@
 ---
 - name: bridges | Managing OVS Bridges
   openvswitch_bridge:
-    bridge: "{{ item['name'] }}"
+    bridge: "{{ item['bridge'] }}"
     parent: "{{ item['parent']|default(omit) }}"
     fail_mode: "{{ item['fail_mode']|default('standalone') }}"
     state: "{{ item['state'] }}"
     timeout: "{{ item['timeout']|default(omit) }}"
     vlan: "{{ item['vlan']|default(omit) }}"
   become: true
-  with_items: '{{ openvswitch_bridges_list }}'
-  when: openvswitch_bridges_list is defined
+  with_items: '{{ openvswitch_bridges }}'
+  when: openvswitch_bridges is defined

--- a/tasks/bridges.yml
+++ b/tasks/bridges.yml
@@ -1,12 +1,12 @@
 ---
 - name: bridges | Managing OVS Bridges
   openvswitch_bridge:
-    bridge: "{{ item['bridge'] }}"
+    bridge: "{{ item['name'] }}"
     parent: "{{ item['parent']|default(omit) }}"
     fail_mode: "{{ item['fail_mode']|default('standalone') }}"
     state: "{{ item['state'] }}"
     timeout: "{{ item['timeout']|default(omit) }}"
     vlan: "{{ item['vlan']|default(omit) }}"
   become: true
-  with_items: '{{ openvswitch_bridges }}'
-  when: openvswitch_bridges is defined
+  with_items: '{{ openvswitch_bridges_list }}'
+  when: openvswitch_bridges_list is defined

--- a/tasks/bridges.yml
+++ b/tasks/bridges.yml
@@ -1,6 +1,6 @@
 ---
 - name: bridges | Managing OVS Bridges
-  openvswitch_bridge:
+  openvswitch.openvswitch.openvswitch_bridge:
     bridge: "{{ item['bridge'] }}"
     parent: "{{ item['parent']|default(omit) }}"
     fail_mode: "{{ item['fail_mode']|default('standalone') }}"
@@ -8,5 +8,7 @@
     timeout: "{{ item['timeout']|default(omit) }}"
     vlan: "{{ item['vlan']|default(omit) }}"
   become: true
-  with_items: '{{ openvswitch_bridges }}'
-  when: openvswitch_bridges is defined and not ansible_check_mode
+  loop: "{{ openvswitch_bridges }}"
+  when: 
+    - openvswitch_bridges is defined
+    - not ansible_check_mode

--- a/tasks/bridges.yml
+++ b/tasks/bridges.yml
@@ -9,6 +9,6 @@
     vlan: "{{ item['vlan']|default(omit) }}"
   become: true
   loop: "{{ openvswitch_bridges }}"
-  when: 
+  when:
     - openvswitch_bridges is defined
     - not ansible_check_mode

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: debian | Installing OVS Packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ openvswitch_debian_packages }}"
     state: "present"
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 # tasks file for ansible-openvswitch
+- name: Gather services status.
+  ansible.builtin.service_facts:
+
 - include_tasks: debian.yml
   when: ansible_os_family == "Debian"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 # tasks file for ansible-openvswitch
-- include: debian.yml
+- include_tasks: debian.yml
   when: ansible_os_family == "Debian"
 
-- include: service.yml
+- include_tasks: service.yml
 
-- include: system_tuning.yml
+- include_tasks: system_tuning.yml
 
-- include: bridges.yml
+- include_tasks: bridges.yml
 
-- include: ports.yml
+- include_tasks: ports.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,13 +4,18 @@
   ansible.builtin.service_facts:
   changed_when: false
 
-- ansible.builtin.include_tasks: debian.yml
+- name: main | Include Debian tasks
+  ansible.builtin.include_tasks: debian.yml
   when: ansible_os_family == "Debian"
 
-- ansible.builtin.include_tasks: service.yml
+- name: main | Include service tasks
+  ansible.builtin.include_tasks: service.yml
 
-- ansible.builtin.include_tasks: system_tuning.yml
+- name: main | Include system_tuning tasks
+  ansible.builtin.include_tasks: system_tuning.yml
 
-- ansible.builtin.include_tasks: bridges.yml
+- name: main | Include bridges tasks
+  ansible.builtin.include_tasks: bridges.yml
 
-- ansible.builtin.include_tasks: ports.yml
+- name: main | include ports tasks
+  ansible.builtin.include_tasks: ports.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,16 @@
 ---
 # tasks file for ansible-openvswitch
-- name: Gather services status.
+- name: main | Gather services status
   ansible.builtin.service_facts:
+  changed_when: false
 
-- include_tasks: debian.yml
+- ansible.builtin.include_tasks: debian.yml
   when: ansible_os_family == "Debian"
 
-- include_tasks: service.yml
+- ansible.builtin.include_tasks: service.yml
 
-- include_tasks: system_tuning.yml
+- ansible.builtin.include_tasks: system_tuning.yml
 
-- include_tasks: bridges.yml
+- ansible.builtin.include_tasks: bridges.yml
 
-- include_tasks: ports.yml
+- ansible.builtin.include_tasks: ports.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,5 @@
 - name: main | Include bridges tasks
   ansible.builtin.include_tasks: bridges.yml
 
-- name: main | include ports tasks
+- name: main | Include ports tasks
   ansible.builtin.include_tasks: ports.yml

--- a/tasks/ports.yml
+++ b/tasks/ports.yml
@@ -7,7 +7,5 @@
     tag: "{{ item[1]['tag']|default(omit) }}"
     timeout: "{{ item[0]['timeout']|default(omit) }}"
   become: true
-  with_subelements:
-    - "{{ openvswitch_ports }}"
-    - ports
+  loop: "{{ openvswitch_ports|subelements('ports') }}"
   when: openvswitch_ports is defined

--- a/tasks/ports.yml
+++ b/tasks/ports.yml
@@ -8,4 +8,6 @@
     timeout: "{{ item[0]['timeout']|default(omit) }}"
   become: true
   loop: "{{ openvswitch_ports|subelements('ports') }}"
-  when: openvswitch_ports is defined
+  when: 
+    - openvswitch_ports is defined
+    - not ansible_check_mode

--- a/tasks/ports.yml
+++ b/tasks/ports.yml
@@ -1,6 +1,6 @@
 ---
 - name: ports | Managing OVS Ports
-  openvswitch_port:
+  openvswitch.openvswitch.openvswitch_port:
     bridge: "{{ item[0]['bridge'] }}"
     port: "{{ item[1]['port'] }}"
     state: "{{ item[1]['state'] }}"
@@ -8,6 +8,6 @@
     timeout: "{{ item[0]['timeout']|default(omit) }}"
   become: true
   with_subelements:
-    - '{{ openvswitch_ports }}'
+    - "{{ openvswitch_ports }}"
     - ports
   when: openvswitch_ports is defined

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,7 +1,8 @@
 ---
 - name: service | Ensuring OVS Service Is Started And Enabled On Boot
   service:
-    name: "openvswitch-switch"
-    state: "started"
+    name: 'openvswitch-switch'
+    state: 'started'
     enabled: true
   become: true
+  when: '"openvswitch-switch.service" in ansible_facts.services'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,8 +1,10 @@
 ---
 - name: service | Ensuring OVS Service Is Started And Enabled On Boot
-  service:
-    name: 'openvswitch-switch'
-    state: 'started'
+  ansible.builtin.service:
+    name: "openvswitch-switch"
+    state: "started"
     enabled: true
   become: true
-  when: '"openvswitch-switch.service" in ansible_facts.services'
+  when: >
+    "openvswitch-switch.service" in ansible_facts.services or
+    "openvswitch-switch" in ansible_facts.services

--- a/tasks/system_tuning.yml
+++ b/tasks/system_tuning.yml
@@ -1,9 +1,9 @@
 ---
 - name: system_tuning | Managing sysctl
-  sysctl:
+  ansible.builtin.sysctl:
     name: "{{ item['name'] }}"
     value: "{{ item['value'] }}"
     state: "present"
   become: true
-  with_items: '{{ openvswitch_system_tuning }}'
+  loop: "{{ openvswitch_system_tuning }}"
   when: openvswitch_system_tuning is defined


### PR DESCRIPTION
Move from 'include' to 'include_tasks' in the main.yml file for includes for Ansible 2.16+ support.
